### PR TITLE
SerialCommutator now manages its own serial port

### DIFF
--- a/.bonsai/Bonsai.config
+++ b/.bonsai/Bonsai.config
@@ -2,103 +2,61 @@
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
     <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Arduino" version="2.8.1" />
-    <Package id="Bonsai.Audio" version="2.8.0" />
     <Package id="Bonsai.Core" version="2.8.5" />
     <Package id="Bonsai.Design" version="2.8.5" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.0" />
-    <Package id="Bonsai.Dsp.Design" version="2.8.0" />
     <Package id="Bonsai.Editor" version="2.8.5" />
-    <Package id="Bonsai.Osc" version="2.7.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.Shaders" version="0.27.0" />
-    <Package id="Bonsai.Shaders.Design" version="0.27.0" />
-    <Package id="Bonsai.StarterPack" version="2.8.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.System.Design" version="2.8.0" />
-    <Package id="Bonsai.Vision" version="2.8.0" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
-    <Package id="Bonsai.Windows.Input" version="2.7.0" />
     <Package id="clroni" version="6.1.2" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
-    <Package id="openal.redist" version="2.0.7" />
+    <Package id="Markdig" version="0.38.0" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2849.39" />
+    <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
-    <Package id="OpenEphys.Onix1" version="0.1.0" />
-    <Package id="OpenTK" version="3.1.0" />
-    <Package id="OpenTK.GLControl" version="3.1.0" />
+    <Package id="OpenEphys.Onix1" version="0.4.0" />
+    <Package id="OpenEphys.Onix1.Design" version="0.4.0" />
+    <Package id="OpenEphys.ProbeInterface.NET" version="0.1.1" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
+    <Package id="SvgNet" version="3.3.8" />
     <Package id="System.Buffers" version="4.5.1" />
-    <Package id="System.Linq.Dynamic" version="1.0.7" />
     <Package id="System.Memory" version="4.5.5" />
     <Package id="System.Numerics.Vectors" version="4.5.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />
+    <Package id="YamlDotNet" version="16.1.3" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
     <AssemblyReference assemblyName="Bonsai" />
-    <AssemblyReference assemblyName="Bonsai.Arduino" />
-    <AssemblyReference assemblyName="Bonsai.Audio" />
     <AssemblyReference assemblyName="Bonsai.Core" />
     <AssemblyReference assemblyName="Bonsai.Design" />
     <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
-    <AssemblyReference assemblyName="Bonsai.Dsp" />
-    <AssemblyReference assemblyName="Bonsai.Dsp.Design" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
-    <AssemblyReference assemblyName="Bonsai.Osc" />
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
-    <AssemblyReference assemblyName="Bonsai.Shaders" />
-    <AssemblyReference assemblyName="Bonsai.Shaders.Design" />
-    <AssemblyReference assemblyName="Bonsai.System" />
-    <AssemblyReference assemblyName="Bonsai.System.Design" />
-    <AssemblyReference assemblyName="Bonsai.Vision" />
-    <AssemblyReference assemblyName="Bonsai.Vision.Design" />
-    <AssemblyReference assemblyName="Bonsai.Windows.Input" />
     <AssemblyReference assemblyName="OpenEphys.Onix1" />
+    <AssemblyReference assemblyName="OpenEphys.Onix1.Design" />
+    <AssemblyReference assemblyName="OpenEphys.ProbeInterface.NET" />
   </AssemblyReferences>
   <AssemblyLocations>
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Arduino" processorArchitecture="MSIL" location="Packages/Bonsai.Arduino.2.8.1/lib/net462/Bonsai.Arduino.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Audio" processorArchitecture="MSIL" location="Packages/Bonsai.Audio.2.8.0/lib/net462/Bonsai.Audio.dll" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.Design.2.8.0/lib/net462/Bonsai.Dsp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Osc" processorArchitecture="MSIL" location="Packages/Bonsai.Osc.2.7.0/lib/net462/Bonsai.Osc.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Shaders" processorArchitecture="MSIL" location="Packages/Bonsai.Shaders.0.27.0/lib/net462/Bonsai.Shaders.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Shaders.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Shaders.Design.0.27.0/lib/net462/Bonsai.Shaders.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages/Bonsai.System.Design.2.8.0/lib/net462/Bonsai.System.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.0/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Windows.Input" processorArchitecture="MSIL" location="Packages/Bonsai.Windows.Input.2.7.0/lib/net462/Bonsai.Windows.Input.dll" />
     <AssemblyLocation assemblyName="clroni" processorArchitecture="Amd64" location="Packages/clroni.6.1.2/lib/net472/clroni.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.38.0/lib/net462/Markdig.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2849.39/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2849.39/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2849.39/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
-    <AssemblyLocation assemblyName="OpenEphys.Onix1" processorArchitecture="Amd64" location="Packages/OpenEphys.Onix1.0.1.0/lib/net472/OpenEphys.Onix1.dll" />
-    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
-    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
+    <AssemblyLocation assemblyName="OpenEphys.Onix1" processorArchitecture="Amd64" location="Packages/OpenEphys.Onix1.0.4.0/lib/net472/OpenEphys.Onix1.dll" />
+    <AssemblyLocation assemblyName="OpenEphys.Onix1.Design" processorArchitecture="Amd64" location="Packages/OpenEphys.Onix1.Design.0.4.0/lib/net472/OpenEphys.Onix1.Design.dll" />
+    <AssemblyLocation assemblyName="OpenEphys.ProbeInterface.NET" processorArchitecture="MSIL" location="Packages/OpenEphys.ProbeInterface.NET.0.1.1/lib/net472/OpenEphys.ProbeInterface.NET.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.8/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
-    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
     <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
     <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
@@ -106,21 +64,19 @@
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.0.0/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.1.3/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
     <LibraryFolder path="Packages/clroni.6.1.2/build/native/bin/x64" platform="x64" />
     <LibraryFolder path="Packages/clroni.6.1.2/build/native/bin/x86" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
-    <LibraryFolder path="Packages/openal.redist.2.0.7.0/build/native/bin/x64" platform="x64" />
-    <LibraryFolder path="Packages/openal.redist.2.0.7.0/build/native/bin/x86" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2849.39/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2849.39/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2849.39/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2849.39/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2849.39/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2849.39/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Commutator/AutoCommutator.bonsai
+++ b/OpenEphys.Commutator/AutoCommutator.bonsai
@@ -3,9 +3,7 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:commutator="clr-namespace:OpenEphys.Commutator;assembly=OpenEphys.Commutator"
-                 xmlns:port="clr-namespace:Bonsai.IO.Ports;assembly=Bonsai.System"
                  xmlns="https://bonsai-rx.org/2018/workflow">
-  <Description>Control an Open Ephys commutator by using rotation angle measurements.</Description>
   <Workflow>
     <Nodes>
       <Expression xsi:type="WorkflowInput">
@@ -16,9 +14,6 @@
           <rx:Interval>PT0.1S</rx:Interval>
         </Combinator>
       </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="RotationAxis" />
-      </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="commutator:QuaternionToTwist">
           <commutator:RotationAxis>
@@ -28,106 +23,23 @@
           </commutator:RotationAxis>
         </Combinator>
       </Expression>
-      <Expression xsi:type="rx:Condition">
-        <Workflow>
-          <Nodes>
-            <Expression xsi:type="WorkflowInput">
-              <Name>Source1</Name>
-            </Expression>
-            <Expression xsi:type="NotEqual">
-              <Operand xsi:type="DoubleProperty">
-                <Value>0</Value>
-              </Operand>
-            </Expression>
-            <Expression xsi:type="WorkflowOutput" />
-          </Nodes>
-          <Edges>
-            <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="2" Label="Source1" />
-          </Edges>
-        </Workflow>
-      </Expression>
-      <Expression xsi:type="Format">
-        <Format>{{turn : {0}}}</Format>
-        <Selector>it</Selector>
-      </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Value" DisplayName="LedEnable" Description="If true, the commutator's LED will show status information. Otherwise, it will turn off." />
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="BooleanProperty">
-          <Value>false</Value>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="rx:Condition">
-        <Workflow>
-          <Nodes>
-            <Expression xsi:type="WorkflowInput">
-              <Name>Source1</Name>
-            </Expression>
-            <Expression xsi:type="WorkflowOutput" />
-          </Nodes>
-          <Edges>
-            <Edge From="0" To="1" Label="Source1" />
-          </Edges>
-        </Workflow>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="StringProperty">
-          <Value>{led: true}</Value>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="rx:Condition">
-        <Workflow>
-          <Nodes>
-            <Expression xsi:type="WorkflowInput">
-              <Name>Source1</Name>
-            </Expression>
-            <Expression xsi:type="BitwiseNot" />
-            <Expression xsi:type="WorkflowOutput" />
-          </Nodes>
-          <Edges>
-            <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="2" Label="Source1" />
-          </Edges>
-        </Workflow>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="StringProperty">
-          <Value>{led: false}</Value>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="rx:Merge" />
-      </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="PortName" />
+        <Property Name="Enable" />
+        <Property Name="EnableLed" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="port:SerialWriteLine">
-          <port:PortName />
-          <port:NewLine>\r\n</port:NewLine>
+        <Combinator xsi:type="commutator:SerialCommutator">
+          <commutator:Enable>true</commutator:Enable>
+          <commutator:EnableLed>true</commutator:EnableLed>
         </Combinator>
       </Expression>
-      <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
       <Edge From="0" To="1" Label="Source1" />
-      <Edge From="1" To="3" Label="Source1" />
-      <Edge From="2" To="3" Label="Source2" />
-      <Edge From="3" To="4" Label="Source1" />
-      <Edge From="4" To="5" Label="Source1" />
-      <Edge From="5" To="12" Label="Source1" />
-      <Edge From="6" To="7" Label="Source1" />
-      <Edge From="7" To="8" Label="Source1" />
-      <Edge From="7" To="10" Label="Source1" />
-      <Edge From="8" To="9" Label="Source1" />
-      <Edge From="9" To="12" Label="Source2" />
-      <Edge From="10" To="11" Label="Source1" />
-      <Edge From="11" To="12" Label="Source3" />
-      <Edge From="12" To="14" Label="Source1" />
-      <Edge From="13" To="14" Label="Source2" />
-      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="4" Label="Source1" />
+      <Edge From="3" To="4" Label="Source2" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/OpenEphys.Commutator/AutoCommutator.bonsai
+++ b/OpenEphys.Commutator/AutoCommutator.bonsai
@@ -34,12 +34,14 @@
           <commutator:EnableLed>true</commutator:EnableLed>
         </Combinator>
       </Expression>
+      <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
       <Edge From="0" To="1" Label="Source1" />
       <Edge From="1" To="2" Label="Source1" />
       <Edge From="2" To="4" Label="Source1" />
       <Edge From="3" To="4" Label="Source2" />
+      <Edge From="4" To="5" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/OpenEphys.Commutator/PortTypeConverter.cs
+++ b/OpenEphys.Commutator/PortTypeConverter.cs
@@ -1,0 +1,41 @@
+﻿using System.ComponentModel;
+using System.IO.Ports;
+using System.Linq;
+using Bonsai;
+using Bonsai.Expressions;
+using Bonsai.IO.Ports;
+
+namespace OpenEphys.Commutator
+{
+    class PortNameConverter : StringConverter
+    {
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            if (context != null)
+            {
+                var workflowBuilder = (WorkflowBuilder)context.GetService(typeof(WorkflowBuilder));
+                if (workflowBuilder != null)
+                {
+                    var portNames = (from builder in workflowBuilder.Workflow.Descendants()
+                                     where builder is not DisableBuilder
+                                     let createPort = ExpressionBuilder.GetWorkflowElement(builder) as CreateSerialPort
+                                     where createPort != null && !string.IsNullOrEmpty(createPort.PortName)
+                                     select !string.IsNullOrEmpty(createPort.Name) ? createPort.Name : createPort.PortName)
+                                     .Distinct()
+                                     .ToList();
+                    if (portNames.Count > 0)
+                    {
+                        return new StandardValuesCollection(portNames);
+                    }
+                }
+            }
+
+            return new StandardValuesCollection(SerialPort.GetPortNames());
+        }
+    }
+}

--- a/OpenEphys.Commutator/QuaternionToTwist.cs
+++ b/OpenEphys.Commutator/QuaternionToTwist.cs
@@ -11,7 +11,8 @@ namespace OpenEphys.Commutator
     /// Calculates a the rotation about a specified axis (the "twist") that has occurred between successive 3D 
     /// rotation measurements.
     /// </summary>
-    [Description("Calculates a feedback control signal to compensate for twisting about the specified axis, in units of turns.")]
+    [Description("Calculates a the rotation about a specified axis (the \"twist\") that has " +
+        "occurred between successive 3D rotation measurements.")]
     public class QuaternionToTwist : Combinator<Quaternion, double>
     {
         /// <summary>

--- a/OpenEphys.Commutator/SerialCommutator.cs
+++ b/OpenEphys.Commutator/SerialCommutator.cs
@@ -78,7 +78,7 @@ namespace OpenEphys.Commutator
                 },
                 s =>
                 {
-                    var turnCommands = source.Where(x => !double.IsNaN(x) && !double.IsInfinity(x)).Select(x => $"{{turn:{x}}}");
+                    var turnCommands = source.Where(x => !double.IsNaN(x) && !double.IsInfinity(x) && x != 0).Select(x => $"{{turn:{x}}}");
                     var enabledCommands = enabled.Select(x => x ? "true" : "false").Select(x => $"{{enable:{x}}}");
                     var ledCommands = led.Select(x => x ? "true" : "false").Select(x => $"{{led:{x}}}");
                     return turnCommands

--- a/OpenEphys.Commutator/SerialCommutator.cs
+++ b/OpenEphys.Commutator/SerialCommutator.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO.Ports;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Bonsai;
+
+namespace OpenEphys.Commutator
+{
+    /// <summary>
+    /// Represents an operator controls an Open Ephys commutator by writing a JSON-encoded
+    /// representations of each element of the input sequence to a serial port and produces the
+    /// JSON-encoded command string.
+    /// </summary>
+    [Description("Controls an Open Ephys commutator using a serial port.")]
+    public class SerialCommutator : Combinator<double, string>
+    {
+
+        const string ConfigurationCategory = "Configuration";
+        const string AcquisitionCategory = "Acquisition";
+
+        readonly BehaviorSubject<bool> enabled = new(true);
+        readonly BehaviorSubject<bool> led = new(true);
+
+        /// <summary>
+        /// Gets or sets the name of the serial port.
+        /// </summary>
+        [Category(ConfigurationCategory)]
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the commutator enable state.
+        /// </summary>
+        /// <remarks>
+        /// If true, the commutator will activate the motor and respond to turn commands. If false,
+        /// the motor driver will be deactivated and motion commands will be ignored.
+        /// </remarks>
+        [Category(AcquisitionCategory)]
+        [Description("If true, the commutator will be enabled. If false, it will disable the motor and ignore motion commands.")]
+        public bool Enable
+        {
+            get => enabled.Value;
+            set => enabled.OnNext(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the commutator indication LED enable state.
+        /// </summary>
+        /// <remarks>
+        /// If true, the commutator indication LED turn on. If false, the indication LED will turn
+        /// off.
+        /// </remarks>
+        [Category(AcquisitionCategory)]
+        [Description("If true, the commutator indication LED turn on. If false, the indication LED will turn off.")]
+        public bool EnableLed
+        {
+            get => led.Value;
+            set => led.OnNext(value);
+        }
+
+        /// <summary>
+        /// Writes a JSON-encoded representations of each element of the input sequence, as well as
+        /// configuration property values, to a serial port.
+        /// </summary>
+        /// <param name="source">A sequence of motor turn values in units of full rotations.</param>
+        /// <returns>JSON-encoded command string sent to the commutator.</returns>
+        public override IObservable<string> Process(IObservable<double> source)
+        {
+            return Observable.Using(
+                () =>
+                {
+                    var s = new SerialPort(PortName);
+                    s.Open();
+                    return s;
+                },
+                s =>
+                {
+                    var turnCommands = source.Select(x => $"{{turn:{x}}}");
+                    var enabledCommands = enabled.Select(x => x ? "true" : "false").Select(x => $"{{enable:{x}}}");
+                    var ledCommands = led.Select(x => x ? "true" : "false").Select(x => $"{{led:{x}}}");
+                    return turnCommands
+                        .Merge(enabledCommands)
+                        .Merge(ledCommands)
+                        .Do(command => s.Write(command));
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
- This is an attempt at getting around a possible issue with Bonsai's serial port libary implementation which is failing on some machines.
- Not sure if it will fix anything
- SerialCommutator is now used in AutoCommuator
- Fixes #8