### PR TITLE
Replace quaternion to twist with new algorithm

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.2.2</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
     <Features>strict</Features>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.2.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Commutator/QuaternionToTwist.cs
+++ b/OpenEphys.Commutator/QuaternionToTwist.cs
@@ -16,7 +16,7 @@ namespace OpenEphys.Commutator
     public class QuaternionToTwist : Combinator<Quaternion, double>
     {
         /// <summary>
-        /// Gets or sets the direction vector specifying the axis around which to calculate the twist.
+        /// Gets or sets the direction vector specifying the axis relative to the headstage where the tether is connected.
         /// </summary>
         /// <remarks>
         /// This vector should point, using the reference frame of the device producing rotation measurements, 
@@ -25,19 +25,31 @@ namespace OpenEphys.Commutator
         /// </remarks>
         [Category(Definitions.ConfigurationCategory)]
         [TypeConverter(typeof(NumericRecordConverter))]
-        [Description("The direction vector specifying the axis around which to calculate the twist.")]
-        public Vector3 RotationAxis { get; set; } = Vector3.UnitZ;
+        [Description("The direction vector specifying the axis relative to the headstage where the tether is connected.")]
+        public Vector3 HeadstageAxis { get; set; } = Vector3.UnitZ;
+
 
         /// <summary>
-        /// Calculates a twist about <see cref="RotationAxis"/> that has occurred between successive rotation 
+        /// Gets or sets the direction vector speciying the axis representing the direction in which the tether is plugged into the commutator
+        /// </summary>
+        /// <remarks>
+        /// This vector should point, using the global reference frame, in the direction that the tether enters the rotating
+        /// element of the commutator. For a usual vertical, upright mouting, this would be Z. 
+        /// </remarks>
+        [Category(Definitions.ConfigurationCategory)]
+        [TypeConverter(typeof(NumericRecordConverter))]
+        [Description("The direction vector specifying the axis representing the direction in which the tether is plugged into the commutator.")]
+        public Vector3 CommutatorAxis { get; set; } = Vector3.UnitZ;
+
+        /// <summary>
+        /// Calculates a twist about <see cref="HeadstageAxis"/> 
+        /// and <see cref="CommutatorAxis"/>that has occurred between successive rotation 
         /// measurements provided by the input sequence.
         /// </summary>
         /// <param name="source">The sequence of rotation measurements.</param>
         /// <returns>The sequence of twist values, in units of turns.</returns>
         public override IObservable<double> Process(IObservable<Quaternion> source)
         {
-            var rotationAxis = RotationAxis;
-
             return Observable.Defer(() =>
             {
                 Quaternion? previousQuaternion = null;
@@ -53,17 +65,29 @@ namespace OpenEphys.Commutator
                         var last = previousQuaternion.Value;
                         //Calculate the incremental rotation
                         var conjugate = Quaternion.Conjugate(last);
-                        var delta =current * conjugate;
+                        var delta =Quaternion.Normalize(current * conjugate); //normalize to ensure there are no rounding errors
 
                         //Rotate RotationAxis to the last known global coordinates
-                        var axis = new Quaternion(RotationAxis, 0);
-                        var projection = (last * axis) * conjugate;
+                        var localAxis = new Quaternion(HeadstageAxis, 0);
+                        var projection = Quaternion.Normalize((last * localAxis) * conjugate);
 
                         //Get how much the new rotation is performed through the last axis projected in global coordinates
                         var deltaV = new Vector3(delta.X, delta.Y, delta.Z);
                         var projectionV = new Vector3(projection.X, projection.Y, projection.Z);
-                        var dotProduct = Vector3.Dot(deltaV, projectionV);
-                        twist = 2 * Math.Atan2(dotProduct, delta.W);
+                        var localDotProduct = Vector3.Dot(deltaV, projectionV);
+                        double localTwist = 2 * Math.Atan2(localDotProduct, delta.W);
+
+                        //Get how much of the new rotation is performed through the commutator axis in global coordinates
+                        var globalDotProduct = Vector3.Dot(deltaV, CommutatorAxis);
+                        var globalTwist = 2*Math.Atan2(globalDotProduct, delta.W);
+
+                        //get the cosine from the rotated axis and the commutator axis
+                        //since vectors are normalised, this is just the dot product
+                        var cos_angle = Vector3.Dot(projectionV,CommutatorAxis);
+
+                        //Remove the local twist from the global rotation to get a weighted total rotation
+                        twist = localTwist + (globalTwist - localTwist*cos_angle);
+
                     }
 
                     previousQuaternion = current;

--- a/OpenEphys.Commutator/QuaternionToTwist.cs
+++ b/OpenEphys.Commutator/QuaternionToTwist.cs
@@ -42,6 +42,32 @@ namespace OpenEphys.Commutator
         public Vector3 CommutatorAxis { get; set; } = Vector3.UnitZ;
 
         /// <summary>
+        /// Gets or sets the threshold in which the twist is not fully calculated and a fallback is used
+        /// </summary>
+        /// <remarks>
+        /// The twist algorithm has a pole when the cosine of the angle between the tether and commutator axes
+        /// approaches zero (i.e.: they are complete opposites). When this happens, a fallback needs to be used
+        /// </remarks>
+        [Category(Definitions.ConfigurationCategory)]
+        [Range(-0.9999,0.5)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("Threshold in which the twist is not fully calculated and a fallback is used.")]
+        public double FallbackThreshold { get; set; } = -0.9;
+
+        /// <summary>
+        /// Defines the possible fallback modes for when the algorithm reaches the pole
+        /// </summary>
+        public enum FallbackRotationModes { Global, Local}
+
+        /// <summary>
+        /// Gets of set the fallback rotation that should be used when the twist algorithm reaches
+        /// the threshold set on <see cref="FallbackThreshold"/>
+        /// </summary>
+        [Category(Definitions.ConfigurationCategory)]
+        [Description("Rotation to use when headstage angle reraches the fallback threshold")]
+        public FallbackRotationModes FallbackRotation { get; set; } = FallbackRotationModes.Global;
+
+        /// <summary>
         /// Calculates a twist about <see cref="HeadstageAxis"/> 
         /// and <see cref="CommutatorAxis"/>that has occurred between successive rotation 
         /// measurements provided by the input sequence.
@@ -85,8 +111,11 @@ namespace OpenEphys.Commutator
                         //since vectors are normalised, this is just the dot product
                         var cos_angle = Vector3.Dot(projectionV,CommutatorAxis);
 
-                        //Remove the local twist from the global rotation to get a weighted total rotation
-                        twist = localTwist + (globalTwist - localTwist*cos_angle);
+                        //Get total angle, correct for the mathematical pole
+                        if (cos_angle > FallbackThreshold)
+                            twist = (localTwist + globalTwist) / (1.0 + cos_angle);
+                        else
+                            twist = FallbackRotation == FallbackRotationModes.Global ? globalTwist : localTwist;
 
                     }
 

--- a/OpenEphys.Commutator/QuaternionToTwist.cs
+++ b/OpenEphys.Commutator/QuaternionToTwist.cs
@@ -40,27 +40,36 @@ namespace OpenEphys.Commutator
 
             return Observable.Defer(() =>
             {
-                double? previousAngleAboutAxis = default;
+                Quaternion? previousQuaternion = null;
                 return source.Select(rotation =>
                 {
-                    // project rotation axis onto the direction axis
-                    var vectorPart = new Vector3(rotation.X, rotation.Y, rotation.Z);
-                    var dotProduct = Vector3.Dot(vectorPart, rotationAxis);
-                    var projection = dotProduct / Vector3.Dot(rotationAxis, rotationAxis) * rotationAxis;
-                    var rotationAboutAxis = new Quaternion(projection, rotation.W);
-                    rotationAboutAxis = Quaternion.Normalize(rotationAboutAxis);
-                    if (dotProduct < 0) // account for angle-axis flipping
+                    double twist = 0;
+                    if (rotation.Length() == 0) return 0;
+
+                    //Normalize the quaternion
+                    var current = Quaternion.Normalize(rotation);
+                    if (previousQuaternion.HasValue)
                     {
-                        rotationAboutAxis = -rotationAboutAxis;
+                        var last = previousQuaternion.Value;
+                        //Calculate the incremental rotation
+                        var conjugate = Quaternion.Conjugate(last);
+                        var delta =current * conjugate;
+
+                        //Rotate RotationAxis to the last known global coordinates
+                        var axis = new Quaternion(RotationAxis, 0);
+                        var projection = (last * axis) * conjugate;
+
+                        //Get how much the new rotation is performed through the last axis projected in global coordinates
+                        var deltaV = new Vector3(delta.X, delta.Y, delta.Z);
+                        var projectionV = new Vector3(projection.X, projection.Y, projection.Z);
+                        var dotProduct = Vector3.Dot(deltaV, projectionV);
+                        twist = 2 * Math.Atan2(dotProduct, delta.W);
                     }
 
-                    // normalize twist feedback in units of turns
-                    var angleAboutAxis = 2 * Math.Acos(rotationAboutAxis.W);
-                    var twist = previousAngleAboutAxis.HasValue
-                        ? (angleAboutAxis - previousAngleAboutAxis.GetValueOrDefault() + 3 * Math.PI) % (2 * Math.PI) - Math.PI
-                        : 0;
-                    previousAngleAboutAxis = angleAboutAxis;
-                    return -twist / (2 * Math.PI);
+                    previousQuaternion = current;
+
+
+                    return double.IsNaN(twist) ? 0 : -twist / (2 * Math.PI);
                 });
             });
         }

--- a/OpenEphys.Commutator/QuaternionToTwist.cs
+++ b/OpenEphys.Commutator/QuaternionToTwist.cs
@@ -55,9 +55,27 @@ namespace OpenEphys.Commutator
         public double FallbackThreshold { get; set; } = -0.9;
 
         /// <summary>
-        /// Defines the possible fallback modes for when the algorithm reaches the pole
+        /// Defines the possible fallback modes for when the algorithm reaches the 
+        /// mathematical pole defined un <see cref="FallbackThreshold"/>
         /// </summary>
-        public enum FallbackRotationModes { Global, Local}
+        public enum FallbackRotationModes { 
+            /// <summary>
+            /// Use the global coordinate axis as rotation origin
+            /// </summary>
+            /// <remarks>
+            /// Fallback mode on the pole will asume rotations are
+            /// orbital motions around the commutator
+            /// </remarks>
+            Global,
+            /// <summary>
+            /// Use the local coordinate axis as rotation origin
+            /// </summary>
+            /// <remarks>
+            /// Fallback mode on the pole will asume rotations are
+            /// rotations around the headstage tether axis
+            /// </remarks>
+            Local
+        }
 
         /// <summary>
         /// Gets of set the fallback rotation that should be used when the twist algorithm reaches


### PR DESCRIPTION
The new algorithm is intended to work better on any orientation.

With this change, the `RotationAxis` property properly defines which axis on the IMU, from its physical representation, is to be used for turning computations. 