### PR TITLE
Add `PackageType` NuGet tag

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
     <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
     <Features>strict</Features>
+    <PackageType>Dependency;BonsaiLibrary</PackageType>
   </PropertyGroup>
 
   <Import Project="build/Version.props" />


### PR DESCRIPTION
so that this package isn't hidden behind the "Show Advanced" checkbox in the Bonsai package manager.

---

Fix #15 