### PR TITLE
Fix turn command formatting to use InvariantCulture

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Commutator/SerialCommutator.cs
+++ b/OpenEphys.Commutator/SerialCommutator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO.Ports;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -76,7 +77,7 @@ namespace OpenEphys.Commutator
                 },
                 s =>
                 {
-                    var turnCommands = source.Where(x => !double.IsNaN(x) && !double.IsInfinity(x) && x != 0).Select(x => $"{{turn:{x}}}");
+                    var turnCommands = source.Where(x => !double.IsNaN(x) && !double.IsInfinity(x) && x != 0).Select(x => $"{{turn:{x.ToString(CultureInfo.InvariantCulture)}}}");
                     var enabledCommands = enabled.Select(x => x ? "true" : "false").Select(x => $"{{enable:{x}}}");
                     var ledCommands = led.Select(x => x ? "true" : "false").Select(x => $"{{led:{x}}}");
                     return turnCommands


### PR DESCRIPTION
This PR forces all turn commands to use `InvariantCulture` when formatting the string, where the decimal separator is a period (`.`).  

Fixes #17 